### PR TITLE
Removed duplicate config paramater

### DIFF
--- a/config/pai.conf.example
+++ b/config/pai.conf.example
@@ -31,9 +31,9 @@ IP_CONNECTION_HOST = '127.0.0.1'	# IP Module address when using direct IP Connec
 IP_CONNECTION_PORT = 10000		    # IP Module port when using direct IP Connection
 IP_CONNECTION_PASSWORD = b'paradox' # IP Module password. "paradox" is default.
 IP_CONNECTION_SITEID = None 		# SITE ID. IF defined, connection will be made through this method.
-IP_CONNECTION_EMAIL = None 		# Email registered in the site
-IP_CONNECTION_PANEL_SERIAL = None  # Use a specific panel. Set it to None to use the first
-IP_CONNECTION_BARE = False      # No not expect an IP150 module. Used this for base Serial over TCP tunnels
+IP_CONNECTION_EMAIL = None 			# Email registered in the site
+IP_CONNECTION_PANEL_SERIAL = None  	# Use a specific panel. Set it to None to use the first
+IP_CONNECTION_BARE = False      	# No not expect an IP150 module. Used this for base Serial over TCP tunnels
 
 # Paradox
 KEEP_ALIVE_INTERVAL = 10   		# Interval between status updates
@@ -64,7 +64,7 @@ PUSH_POWER_UPDATE_WITHOUT_CHANGE = True # Always notify interfaces of power chan
 PUSH_UPDATE_WITHOUT_CHANGE = False      # Always notify interfaces of all changes
 
 # MQTT
-MQTT_ENABLE = False			# Enable MQTT Interface
+MQTT_ENABLE = False				# Enable MQTT Interface
 MQTT_HOST = 'localhost' 		# Hostname or address
 MQTT_PORT = 1883        		# TCP Port
 MQTT_KEEPALIVE = 60     		# Keep alive

--- a/config/pai.conf.example
+++ b/config/pai.conf.example
@@ -146,13 +146,10 @@ MQTT_PARTITION_HOMEASSISTANT_COMMANDS = dict(
                                 ARM_NIGHT='arm_sleep',
                                 DISARM='disarm')
 
-# Dash App
-MQTT_DASH_PUBLISH = False
+# MQTT Dash App
+MQTT_DASH_PUBLISH = False				# Change this to TRUE if you want to use the MQTT Dash App
 MQTT_DASH_TOPIC = 'metrics/exchange/pai'
 MQTT_DASH_TEMPLATE = '/etc/pai/mqtt_dash.txt'
-
-# MQTT Dash
-MQTT_DASH_PUBLISH = False
 
 # Interfaces
 COMMAND_ALIAS = {						# alias for commands through text based interfaces

--- a/config/pai.conf.example
+++ b/config/pai.conf.example
@@ -147,7 +147,7 @@ MQTT_PARTITION_HOMEASSISTANT_COMMANDS = dict(
                                 DISARM='disarm')
 
 # MQTT Dash App
-MQTT_DASH_PUBLISH = False				# Change this to TRUE if you want to use the MQTT Dash App
+MQTT_DASH_PUBLISH = False				# Enable MQTT Dash App
 MQTT_DASH_TOPIC = 'metrics/exchange/pai'
 MQTT_DASH_TEMPLATE = '/etc/pai/mqtt_dash.txt'
 


### PR DESCRIPTION
The requested MQTT_DASH_PUBLISH parameter got duplicated here.
Also added a little help when this parameter should be used.